### PR TITLE
Migrate to Godot 4.2 / Refactor Player Script / Fix Bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,15 @@
 # Godot 4+ specific ignores
 .godot/
+
+# Godot-specific ignores
+.import/
+export.cfg
+export_presets.cfg
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json

--- a/icon.svg.import
+++ b/icon.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.cte
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/project.godot
+++ b/project.godot
@@ -8,57 +8,11 @@
 
 config_version=5
 
-_global_script_classes=[{
-"base": "Resource",
-"class": &"CombatStat",
-"language": &"GDScript",
-"path": "res://scripts/shared/combat_stat.gd"
-}, {
-"base": "Node",
-"class": &"Damageable",
-"language": &"GDScript",
-"path": "res://scripts/shared/damageable.gd"
-}, {
-"base": "Node2D",
-"class": &"Grass",
-"language": &"GDScript",
-"path": "res://scripts/grass.gd"
-}, {
-"base": "Area2D",
-"class": &"Hitbox",
-"language": &"GDScript",
-"path": "res://scripts/shared/hitbox.gd"
-}, {
-"base": "CharacterBody2D",
-"class": &"Player",
-"language": &"GDScript",
-"path": "res://scripts/player.gd"
-}, {
-"base": "Area2D",
-"class": &"TargetDetector",
-"language": &"GDScript",
-"path": "res://scripts/shared/target_detection_zone.gd"
-}, {
-"base": "Node2D",
-"class": &"WanderController",
-"language": &"GDScript",
-"path": "res://scripts/wander_controller.gd"
-}]
-_global_script_class_icons={
-"CombatStat": "",
-"Damageable": "",
-"Grass": "",
-"Hitbox": "",
-"Player": "",
-"TargetDetector": "",
-"WanderController": ""
-}
-
 [application]
 
 config/name="Brave Fox"
 run/main_scene="res://scenes/world.tscn"
-config/features=PackedStringArray("4.0", "Mobile")
+config/features=PackedStringArray("4.2", "Mobile")
 config/icon="res://icon.svg"
 
 [autoload]
@@ -78,42 +32,42 @@ window/stretch/aspect="keep_width"
 
 ui_left={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194319,"physical_keycode":0,"unicode":4194319,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194319,"physical_keycode":0,"key_label":0,"unicode":4194319,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 ui_right={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194321,"physical_keycode":0,"unicode":4194321,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194321,"physical_keycode":0,"key_label":0,"unicode":4194321,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 ui_up={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194320,"physical_keycode":0,"unicode":4194320,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194320,"physical_keycode":0,"key_label":0,"unicode":4194320,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 ui_down={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194322,"physical_keycode":0,"unicode":4194322,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194322,"physical_keycode":0,"key_label":0,"unicode":4194322,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 attack={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":90,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":74,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":90,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":74,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 roll={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":88,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":75,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":88,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":75,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 

--- a/scenes/effects/grass_wither_vfx.tscn
+++ b/scenes/effects/grass_wither_vfx.tscn
@@ -25,13 +25,28 @@ region = Rect2(128, 0, 32, 32)
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_4ad0x"]
 animations = [{
-"frames": [SubResource("AtlasTexture_0itsm"), SubResource("AtlasTexture_ytap2"), SubResource("AtlasTexture_h5va1"), SubResource("AtlasTexture_tli7c"), SubResource("AtlasTexture_h6jsv")],
-"loop": true,
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_0itsm")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ytap2")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_h5va1")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_tli7c")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_h6jsv")
+}],
+"loop": false,
 "name": &"default",
 "speed": 5.0
 }]
 
 [node name="GrassWitherVfx" type="AnimatedSprite2D"]
 texture_filter = 1
-frames = SubResource("SpriteFrames_4ad0x")
+sprite_frames = SubResource("SpriteFrames_4ad0x")
 script = ExtResource("1_xqjvd")

--- a/scenes/effects/hit_vfx.tscn
+++ b/scenes/effects/hit_vfx.tscn
@@ -13,12 +13,18 @@ region = Rect2(24, 0, 24, 24)
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_oqqaj"]
 animations = [{
-"frames": [SubResource("AtlasTexture_2xc1k"), SubResource("AtlasTexture_5hr0i")],
-"loop": true,
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_2xc1k")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_5hr0i")
+}],
+"loop": false,
 "name": &"default",
 "speed": 10.0
 }]
 
 [node name="HitVfx" type="AnimatedSprite2D"]
-frames = SubResource("SpriteFrames_oqqaj")
+sprite_frames = SubResource("SpriteFrames_oqqaj")
 script = ExtResource("2_k3im6")

--- a/scenes/effects/player_death_vfx.tscn
+++ b/scenes/effects/player_death_vfx.tscn
@@ -45,12 +45,42 @@ region = Rect2(288, 0, 32, 32)
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_dindh"]
 animations = [{
-"frames": [SubResource("AtlasTexture_akg6d"), SubResource("AtlasTexture_5mglb"), SubResource("AtlasTexture_ylagu"), SubResource("AtlasTexture_j5ujl"), SubResource("AtlasTexture_bn3be"), SubResource("AtlasTexture_75v8g"), SubResource("AtlasTexture_vr6dp"), SubResource("AtlasTexture_g37j1"), SubResource("AtlasTexture_nsqly"), SubResource("AtlasTexture_l75w6")],
-"loop": true,
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_akg6d")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_5mglb")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ylagu")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_j5ujl")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_bn3be")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_75v8g")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_vr6dp")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_g37j1")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_nsqly")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_l75w6")
+}],
+"loop": false,
 "name": &"default",
 "speed": 5.0
 }]
 
 [node name="PlayerDeathVfx" type="AnimatedSprite2D"]
-frames = SubResource("SpriteFrames_dindh")
+sprite_frames = SubResource("SpriteFrames_dindh")
 script = ExtResource("1_4ch76")

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=63 format=3 uid="uid://c2my0vtkton55"]
+[gd_scene load_steps=62 format=3 uid="uid://c2my0vtkton55"]
 
 [ext_resource type="Script" path="res://scripts/player.gd" id="1_1wicd"]
 [ext_resource type="Texture2D" uid="uid://cfhwtjynh1t8w" path="res://sprites/Player/Player.png" id="1_3wlxc"]
@@ -136,6 +136,7 @@ tracks/4/keys = {
 }],
 "times": PackedFloat32Array(0.1)
 }
+tracks/4/use_blend = true
 
 [sub_resource type="Animation" id="Animation_eeeia"]
 resource_name = "AttackLeft"
@@ -204,6 +205,7 @@ tracks/4/keys = {
 }],
 "times": PackedFloat32Array(0.1)
 }
+tracks/4/use_blend = true
 
 [sub_resource type="Animation" id="Animation_rxf2o"]
 resource_name = "AttackRight"
@@ -272,6 +274,7 @@ tracks/4/keys = {
 }],
 "times": PackedFloat32Array(0.1)
 }
+tracks/4/use_blend = true
 
 [sub_resource type="Animation" id="Animation_tqedy"]
 resource_name = "AttackUp"
@@ -340,6 +343,7 @@ tracks/4/keys = {
 }],
 "times": PackedFloat32Array(0.1)
 }
+tracks/4/use_blend = true
 
 [sub_resource type="Animation" id="Animation_6tpbu"]
 resource_name = "IdleDown"
@@ -464,6 +468,7 @@ tracks/3/keys = {
 }],
 "times": PackedFloat32Array(0.1)
 }
+tracks/3/use_blend = true
 
 [sub_resource type="Animation" id="Animation_38wgv"]
 resource_name = "RollLeft"
@@ -520,6 +525,7 @@ tracks/3/keys = {
 }],
 "times": PackedFloat32Array(0.1)
 }
+tracks/3/use_blend = true
 
 [sub_resource type="Animation" id="Animation_kf4ii"]
 resource_name = "RollRight"
@@ -576,6 +582,7 @@ tracks/3/keys = {
 }],
 "times": PackedFloat32Array(0.1)
 }
+tracks/3/use_blend = true
 
 [sub_resource type="Animation" id="Animation_rwkbo"]
 resource_name = "RollUp"
@@ -632,6 +639,7 @@ tracks/3/keys = {
 }],
 "times": PackedFloat32Array(0.1)
 }
+tracks/3/use_blend = true
 
 [sub_resource type="Animation" id="Animation_f0i2n"]
 resource_name = "RunDown"
@@ -790,6 +798,7 @@ blend_point_2/node = SubResource("AnimationNodeAnimation_mlrgq")
 blend_point_2/pos = Vector2(1, 0)
 blend_point_3/node = SubResource("AnimationNodeAnimation_x0hpu")
 blend_point_3/pos = Vector2(-1, 0)
+max_space = Vector2(1, 1.3)
 blend_mode = 1
 
 [sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_i8w4c"]
@@ -818,7 +827,6 @@ max_space = Vector2(1, 1.1)
 blend_mode = 1
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_fqeov"]
-auto_advance = true
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_snjon"]
 
@@ -828,13 +836,11 @@ auto_advance = true
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_y8w8n"]
 switch_mode = 2
-auto_advance = true
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_58yg7"]
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_bd3f7"]
 switch_mode = 2
-auto_advance = true
 
 [sub_resource type="AnimationNodeStateMachine" id="AnimationNodeStateMachine_sdjpc"]
 states/Attack/node = SubResource("AnimationNodeBlendSpace2D_jl4ab")
@@ -847,9 +853,7 @@ states/Running/node = SubResource("AnimationNodeBlendSpace2D_45ayk")
 states/Running/position = Vector2(717, 99)
 states/Start/position = Vector2(372, 100)
 transitions = ["Start", "Idling", SubResource("AnimationNodeStateMachineTransition_fqeov"), "Idling", "Running", SubResource("AnimationNodeStateMachineTransition_snjon"), "Running", "Idling", SubResource("AnimationNodeStateMachineTransition_nyxv2"), "Idling", "Roll", SubResource("AnimationNodeStateMachineTransition_ebmvr"), "Roll", "Idling", SubResource("AnimationNodeStateMachineTransition_y8w8n"), "Idling", "Attack", SubResource("AnimationNodeStateMachineTransition_58yg7"), "Attack", "Idling", SubResource("AnimationNodeStateMachineTransition_bd3f7")]
-graph_offset = Vector2(-234, -28)
-
-[sub_resource type="AnimationNodeStateMachinePlayback" id="AnimationNodeStateMachinePlayback_1qioy"]
+graph_offset = Vector2(-175, -115)
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_ug18x"]
 
@@ -920,11 +924,10 @@ libraries = {
 [node name="AnimationTree" type="AnimationTree" parent="."]
 tree_root = SubResource("AnimationNodeStateMachine_sdjpc")
 anim_player = NodePath("../AnimationPlayer")
-parameters/playback = SubResource("AnimationNodeStateMachinePlayback_1qioy")
 parameters/Attack/blend_position = Vector2(0, 1)
 parameters/Idling/blend_position = Vector2(0, 1)
-parameters/Roll/blend_position = Vector2(0, 1)
-parameters/Running/blend_position = Vector2(0, 1)
+parameters/Roll/blend_position = Vector2(-0.979874, 0)
+parameters/Running/blend_position = Vector2(0, 1.09507)
 
 [node name="SwordPivot" type="Node2D" parent="."]
 position = Vector2(0, -4)
@@ -954,7 +957,6 @@ debug_color = Color(0.431373, 0.592157, 0.321569, 0.419608)
 script = ExtResource("5_ahbq6")
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
-stream = ExtResource("3_7k1s8")
 
 [node name="AnimationPlayerSub" type="AnimationPlayer" parent="."]
 libraries = {

--- a/scenes/world.tscn
+++ b/scenes/world.tscn
@@ -863,7 +863,6 @@ layer_0/tile_data = PackedInt32Array(327680, 0, 3, 327681, 65536, 3, 327682, 393
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(24, 24)
-current = true
 position_smoothing_enabled = true
 
 [node name="YSorted" type="Node2D" parent="."]

--- a/sprites/Effects/EnemyDeathEffect.png.import
+++ b/sprites/Effects/EnemyDeathEffect.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/EnemyDeathEffect.png-caf107a64381844b3069cb10
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/Effects/GrassEffect.png.import
+++ b/sprites/Effects/GrassEffect.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/GrassEffect.png-ac5776a334122b290b66af965dec6
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/Effects/HitEffect.png.import
+++ b/sprites/Effects/HitEffect.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/HitEffect.png-00c0979fa34df09a1fb7787546879f8
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/Enemies/Bat.png.import
+++ b/sprites/Enemies/Bat.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/Bat.png-74b0848ea2b2961ad67f410e9696bc5d.ctex
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/Player/Player.png.import
+++ b/sprites/Player/Player.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/Player.png-e696543efeab372ee2504c59022e467f.c
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/Shadows/LargeShadow.png.import
+++ b/sprites/Shadows/LargeShadow.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/LargeShadow.png-1ddde191b787dd57f527b0f4fb44f
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/Shadows/MediumShadow.png.import
+++ b/sprites/Shadows/MediumShadow.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/MediumShadow.png-e199f84798fcb44caef7be0e0815
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/Shadows/SmallShadow.png.import
+++ b/sprites/Shadows/SmallShadow.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/SmallShadow.png-09ef7f7e5d4fcd7b211fbc3adfe31
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/UI/HeartUIEmpty.png.import
+++ b/sprites/UI/HeartUIEmpty.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/HeartUIEmpty.png-3120283b5d9eebdd14f4f976baa5
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/UI/HeartUIFull.png.import
+++ b/sprites/UI/HeartUIFull.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/HeartUIFull.png-a0892a6eb9a793450f25864c91a4e
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/World/Bush.png.import
+++ b/sprites/World/Bush.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/Bush.png-674e8add3b25b7a552b2aeef2cced6a9.cte
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/World/CliffTileset.png.import
+++ b/sprites/World/CliffTileset.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/CliffTileset.png-bbedae20796a55f290867abac93f
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/World/DirtTileset.png.import
+++ b/sprites/World/DirtTileset.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/DirtTileset.png-6eb89c52dcb04d4595ac3d34d0694
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/World/Grass.png.import
+++ b/sprites/World/Grass.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/Grass.png-2aa10da6819fce504d42f7086b44ba39.ct
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/World/GrassBackground.png.import
+++ b/sprites/World/GrassBackground.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/GrassBackground.png-8cde7b9fe1228a3307b3d084b
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/sprites/World/Tree.png.import
+++ b/sprites/World/Tree.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/Tree.png-75baefd2bfc5d97d9857665ec323a995.cte
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false


### PR DESCRIPTION
### Migrate to Godot 4.2
The migration only broke effects. The animation would cycle infinitely. Fixed it by disabling repeated animations.

### Refactored Player.gd
- Separating triggers from movement updates
- Added new state IDLE
- Updated rolling speed to make it different from the regular move speed
- Added locked_movement logic where the player follows the inertia (attacking or rolling)

### Updated .gitignore
Preventing garbo from being added to commits